### PR TITLE
[PUPPETSERVER] After JDK 8u130 the JVM calculating the heap size based on the RAM available to the container

### DIFF
--- a/s2i/config/sysconfig/puppetserver
+++ b/s2i/config/sysconfig/puppetserver
@@ -6,7 +6,7 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-Xms1536m -Xmx1536m -XX:MaxRAM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) -Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLoggeri -Djruby.invokedynamic.invocation=false"
+JAVA_ARGS="-XX:MaxRAM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) -Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLoggeri -Djruby.invokedynamic.invocation=false"
 
 # Modify this as you would JAVA_ARGS but for non-service related subcommands
 JAVA_ARGS_CLI="${JAVA_ARGS_CLI:-}"


### PR DESCRIPTION
## USD Ticket/RFC number: `-`

## Describe:
#### The issue you're trying to fix and did you check if this happened before?
`JVM was using a fixed value of 1.5GB`

#### The fix for the issue or request
`JDK 8 > u130 can calculate memory automatically`

#### The impact on the promotion of the PR
`Dynamically allocate memory based on the openshift limits``

## Whats the type of change you're proposing:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe): `otherchangetype`

## Potential impact/testing:
- [x] I did not test this change in vagrant
- [ ] code has been tested in vagrant and works
- [ ] code has been tested in vagrant twice to check for idempotency
- [ ] puppet has been disabled on the servers to rollout the code
- [ ] this will restart a service, namely:
  - [ ] `service`

## Environments you're going to impact:
- [ ] dev
- [ ] tst
- [ ] acc
- [ ] prd
- [ ] drp