### PR TITLE
Revert "[PUPPETSERVER] After JDK 8u130 the JVM calculating the heap size based on the RAM available to the container"

### DIFF
--- a/s2i/config/sysconfig/puppetserver
+++ b/s2i/config/sysconfig/puppetserver
@@ -6,7 +6,7 @@
 JAVA_BIN="/usr/bin/java"
 
 # Modify this if you'd like to change the memory allocation, enable JMX, etc
-JAVA_ARGS="-XX:MaxRAM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) -Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLoggeri -Djruby.invokedynamic.invocation=false"
+JAVA_ARGS="-Xms1536m -Xmx1536m -XX:MaxRAM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes) -Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLoggeri -Djruby.invokedynamic.invocation=false"
 
 # Modify this as you would JAVA_ARGS but for non-service related subcommands
 JAVA_ARGS_CLI="${JAVA_ARGS_CLI:-}"


### PR DESCRIPTION
Reverts cegeka/docker-puppetserver#67