### PR TITLE
Ensure group is also writeable for root, required for thycotic module and weird 99 group ownership on nfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN /opt/puppetlabs/server/bin/puppetserver gem install --no-document soap4r-ng 
 
 ## Make /etc/passwd writable for root to be able to adjust the puppet userid. Required for Thycotic module
 RUN chmod g+w /etc/passwd
+    && chmod g+w /etc/group
 
 USER 1001
 

--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -4,10 +4,13 @@
 
 
 if [ `id -u` -ge 10000 ]; then
-    grep -v puppet /etc/passwd > /tmp/passwd
+    grep -v 'puppet' /etc/passwd > /tmp/passwd
+    grep -v 'x:99:' /etc/group > /tmp/group
     echo "puppet:x:`id -u`:`id -g`:puppetserver daemon:/opt/puppetlabs/server/data/puppetserver:/sbin/nologin" >> /tmp/passwd
+    echo "nfslocal:x:99:" >> /tmp/group
     cat /tmp/passwd > /etc/passwd
-    rm /tmp/passwd
+    cat /tmp/group > /etc/group
+    rm /tmp/passwd /tmp/group
 fi
 
 cp /tmp/puppet-scripts/* /etc/puppetlabs/puppetserver/conf.d/ &&  \


### PR DESCRIPTION
## USD Ticket/RFC number: `-`

## Describe:
#### The issue you're trying to fix and did you check if this happened before?
`Puppetserver can't serve thycotic due to permission error on /tmp folder`

#### The fix for the issue or request
`Ensure the correct user and group is present`

#### The impact on the promotion of the PR
`Ownership can be set`

## Whats the type of change you're proposing:
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Other (please describe): `otherchangetype`

## Potential impact/testing:
- [ ] I did not test this change in vagrant
- [x] code has been tested in vagrant and works
- [x] code has been tested in vagrant twice to check for idempotency
- [ ] puppet has been disabled on the servers to rollout the code
- [ ] this will restart a service, namely:
  - [ ] `service`

## Environments you're going to impact:
- [ ] dev
- [ ] tst
- [ ] acc
- [ ] prd
- [ ] drp