### PR TITLE
[PUPPET8] upgrade ubi image to 9 + install puppetserver 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN chmod +x /usr/local/bin/start-puppet-server \
     && chmod -R 771 /etc/puppetlabs/puppet/ssl \
     && chmod -R 775 /etc/puppetlabs/code \
     && chgrp -R 0 /var/log/puppetlabs \
+    && mkdir /opt/puppetlabs/server/data/puppetserver/yaml \
     && chmod 750 /var/log/puppetlabs/puppetserver \
     && chmod 660 /var/log/puppetlabs/puppetserver/masterhttp.log \
     && chmod 660 /var/log/puppetlabs/puppetserver/puppetserver-access.log \

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,11 @@ RUN rpm -i https://yum.puppet.com/puppet8/el/9/x86_64/puppet8-release-1.0.0-9.el
     && mkdir -p /etc/puppetlabs/code \
     && mkdir -p /tmp/puppet-scripts \
     && mkdir -p /tmp/ca-certs \
-    && mkdir -p /etc/puppetlabs/ssl/ca \
+    && mkdir -p /etc/puppetlabs/puppetserver/ca \
     && mkdir -p /etc/puppetlabs/code/environments/production/manifests \
     && mkdir -p /var/log/puppetlabs/puppetserver/ \
-    && touch /var/log/puppetlabs/puppetserver/masterhttp.log
+    && touch /var/log/puppetlabs/puppetserver/masterhttp.log \
+    && touch /var/log/puppetlabs/puppetserver/puppetserver-access.log
 
 ## Copy all required config files
 COPY ./s2i/config/puppetserver.sh /usr/local/bin/start-puppet-server
@@ -46,11 +47,12 @@ RUN chmod +x /usr/local/bin/start-puppet-server \
     && chgrp -R 0 /var/log/puppetlabs \
     && chmod 750 /var/log/puppetlabs/puppetserver \
     && chmod 660 /var/log/puppetlabs/puppetserver/masterhttp.log \
+    && chmod 660 /var/log/puppetlabs/puppetserver/puppetserver-access.log \
     && chmod 750 /opt/puppetlabs/server/data/puppetserver/yaml \
     && mkdir /opt/puppetlabs/puppet/cache/facts.d \
     && mkdir /tmp/thycotic \
-    && chmod 0775 /etc/puppetlabs/ssl/ca \
-    && chmod -R 0771 /etc/puppetlabs/ssl \
+    && chmod 0775 /etc/puppetlabs/puppetserver/ca \
+    && chmod -R 0771 /etc/puppetlabs/puppetserver \
     && chmod 755 /usr/local/bin/cloud_registration.rb
 
 ## Install dependencies for puppet-thycotic module

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN rpm -i https://yum.puppet.com/puppet8/el/9/x86_64/puppet8-release-1.0.0-9.el
     && mkdir -p /etc/puppetlabs/code \
     && mkdir -p /tmp/puppet-scripts \
     && mkdir -p /tmp/ca-certs \
+    && mkdir -p /etc/puppetlabs/ssl/ca \
     && mkdir -p /etc/puppetlabs/puppetserver/ca \
     && mkdir -p /etc/puppetlabs/code/environments/production/manifests \
     && mkdir -p /var/log/puppetlabs/puppetserver/ \
@@ -51,6 +52,8 @@ RUN chmod +x /usr/local/bin/start-puppet-server \
     && chmod 750 /opt/puppetlabs/server/data/puppetserver/yaml \
     && mkdir /opt/puppetlabs/puppet/cache/facts.d \
     && mkdir /tmp/thycotic \
+    && chmod 0775 /etc/puppetlabs/ssl/ca \
+    && chmod -R 0771 /etc/puppetlabs/ssl \
     && chmod 0775 /etc/puppetlabs/puppetserver/ca \
     && chmod -R 0771 /etc/puppetlabs/puppetserver \
     && chmod 755 /usr/local/bin/cloud_registration.rb

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,6 @@ RUN chmod +x /usr/local/bin/start-puppet-server \
     && chmod -R 771 /etc/puppetlabs/puppet/ssl \
     && chmod -R 775 /etc/puppetlabs/code \
     && chgrp -R 0 /var/log/puppetlabs \
-    && mkdir /opt/puppetlabs/server/data/puppetserver/yaml \
     && chmod 750 /var/log/puppetlabs/puppetserver \
     && chmod 660 /var/log/puppetlabs/puppetserver/masterhttp.log \
     && chmod 660 /var/log/puppetlabs/puppetserver/puppetserver-access.log \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Puppetserver docker file
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL maintainer="Thomas Meeus <thomas.meeus@cegeka.com>"
 
 # TODO: Rename the builder environment variable to inform users about application you provide them
@@ -17,7 +17,7 @@ COPY ./s2i/bin/ /usr/libexec/s2i
 
 ## Install Puppetserver & create Puppet code directory
 
-RUN rpm -i https://yum.puppet.com/puppet7/el/8/x86_64/puppet7-release-7.0.0-2.el8.noarch.rpm \
+RUN rpm -i https://yum.puppet.com/puppet8/el/9/x86_64/puppet8-release-1.0.0-9.el9.noarch.rpm \
     && sed -i 's/http:/https:/g' /etc/yum.repos.d/* \
     && microdnf -y update \
     && microdnf -y install vim openssl wget nmap puppetserver puppetdb-termini\
@@ -46,7 +46,6 @@ RUN chmod +x /usr/local/bin/start-puppet-server \
     && chgrp -R 0 /var/log/puppetlabs \
     && chmod 750 /var/log/puppetlabs/puppetserver \
     && chmod 660 /var/log/puppetlabs/puppetserver/masterhttp.log \
-    && mkdir /opt/puppetlabs/server/data/puppetserver/yaml \
     && chmod 750 /opt/puppetlabs/server/data/puppetserver/yaml \
     && mkdir /opt/puppetlabs/puppet/cache/facts.d \
     && mkdir /tmp/thycotic \

--- a/ocp/config/puppet-cloud.conf
+++ b/ocp/config/puppet-cloud.conf
@@ -10,7 +10,7 @@ logdir = /var/log/puppetlabs/puppetserver
 rundir = /var/run/puppetlabs/puppetserver
 pidfile = /var/run/puppetlabs/puppetserver/puppetserver.pid
 codedir = /etc/puppetlabs/code
-ssldir = /etc/puppetlabs/ssl
+ssldir = /etc/puppetlabs/puppetserver/ca
 default_manifest = /etc/puppetlabs/code/environments/production/puppet-files/${ENVIRONMENT}/manifests/
 autosign = /usr/local/bin/cloud_registration.rb
 [main]

--- a/ocp/config/puppet.conf
+++ b/ocp/config/puppet.conf
@@ -10,7 +10,7 @@ logdir = /var/log/puppetlabs/puppetserver
 rundir = /var/run/puppetlabs/puppetserver
 pidfile = /var/run/puppetlabs/puppetserver/puppetserver.pid
 codedir = /etc/puppetlabs/code
-ssldir = /etc/puppetlabs/ssl
+ssldir = /etc/puppetlabs/puppetserver/ca
 default_manifest = /etc/puppetlabs/code/environments/production/puppet-files/${ENVIRONMENT}/manifests/
 [main]
 reports=log, foreman

--- a/ocp/config/puppetserver/puppetserver.conf
+++ b/ocp/config/puppetserver/puppetserver.conf
@@ -16,48 +16,46 @@ jruby-puppet: {
     # PLEASE NOTE: Use caution when modifying the below settings. Modifying
     # these settings will change the value of the corresponding Puppet settings
     # for Puppet Server, but not for the Puppet CLI tools. This likely will not
-    # be a problem with master-var-dir, master-run-dir, or master-log-dir unless
+    # be a problem with server-var-dir, server-run-dir, or server-log-dir unless
     # some critical setting in puppet.conf is interpolating the value of one
     # of the corresponding settings, but it is important that any changes made to
-    # master-conf-dir and master-code-dir are also made to the corresponding Puppet
+    # server-conf-dir and server-code-dir are also made to the corresponding Puppet
     # settings when running the Puppet CLI tools. See
     # https://docs.puppetlabs.com/puppetserver/latest/puppet_conf_setting_diffs.html#overriding-puppet-settings-in-puppet-server
     # for more information.
 
     # (optional) path to puppet conf dir; if not specified, will use
     # /etc/puppetlabs/puppet
-    master-conf-dir: /etc/puppetlabs/puppet
+    server-conf-dir: /etc/puppetlabs/puppet
 
     # (optional) path to puppet code dir; if not specified, will use
     # /etc/puppetlabs/code
-    master-code-dir: /etc/puppetlabs/code
+    server-code-dir: /etc/puppetlabs/code
 
     # (optional) path to puppet var dir; if not specified, will use
     # /opt/puppetlabs/server/data/puppetserver
-    master-var-dir: /opt/puppetlabs/server/data/puppetserver
+    server-var-dir: /opt/puppetlabs/server/data/puppetserver
 
     # (optional) path to puppet run dir; if not specified, will use
     # /var/run/puppetlabs/puppetserver
-    master-run-dir: /var/run/puppetlabs/puppetserver
+    server-run-dir: /var/run/puppetlabs/puppetserver
 
     # (optional) path to puppet log dir; if not specified, will use
     # /var/log/puppetlabs/puppetserver
-    master-log-dir: /var/log/puppetlabs/puppetserver
+    server-log-dir: /var/log/puppetlabs/puppetserver
 
     # (optional) maximum number of JRuby instances to allow
     max-active-instances: 2
 
-    # (optional) Authorize access to Puppet master endpoints via rules
-    # specified in the legacy Puppet auth.conf file (if true) or via rules
-    # specified in the Puppet Server HOCON-formatted auth.conf (if false or not
-    # specified).
-    #use-legacy-auth-conf: true
+    # (optional) Whether or not to track lookups during compilation; turning
+    # this on will send that information to puppetdb
+    track-lookups: false
 }
 
 # settings related to HTTPS client requests made by Puppet Server
 http-client: {
     # A list of acceptable protocols for making HTTPS requests
-    #ssl-protocols: [ TLSv1.1, TLSv1.2 ]
+    #ssl-protocols: [TLSv1.3, TLSv1.2]
 
     # A list of acceptable cipher suites for making HTTPS requests
     #cipher-suites: [TLS_RSA_WITH_AES_256_CBC_SHA256,
@@ -73,4 +71,13 @@ http-client: {
 profiler: {
     # enable or disable profiling for the Ruby code; defaults to 'true'.
     enabled: false
+}
+
+# settings related to submitting module metrics via Dropsonde
+dropsonde: {
+    enabled: false
+
+    # How long, in seconds, to wait between dropsonde submissions
+    # Defaults to one week.
+    # interval: 604800
 }

--- a/s2i/bin/run
+++ b/s2i/bin/run
@@ -15,5 +15,5 @@ fi
 
 cp /tmp/puppet-scripts/* /etc/puppetlabs/puppetserver/conf.d/ &&  \
   sed -i "s/puppetserver_.*/${HOSTNAME}/" /etc/puppetlabs/puppetserver/conf.d/metrics.conf && \
-  cp /tmp/ca-certs/* /etc/puppetlabs/ssl/ca/
+  cp /tmp/ca-certs/* /etc/puppetlabs/puppetserver/ca
 exec /usr/local/bin/start-puppet-server


### PR DESCRIPTION
* Migrate to ubi9 image
* Install puppetserver 8 rpm
* `mkdir /opt/puppetlabs/server/data/puppetserver/yaml \` is duplicate, so gets removed